### PR TITLE
Wire blocksclient get schema

### DIFF
--- a/PRD-blocks-schema.md
+++ b/PRD-blocks-schema.md
@@ -1,0 +1,66 @@
+# PRD: Wire typed schemas for BlocksClient
+
+**Issue**: [#2](https://github.com/TheAPIguys/vintrace-sdk/issues/2)
+
+## Problem Statement
+
+`BlocksClient.get(id)` calls `GET /v7/harvest/blocks/{id}` — an endpoint that does not exist in the v7 OpenAPI spec. There is no single-block retrieval endpoint in v7. The only GET endpoint is the paginated list `GET /v7/harvest/blocks`. Additionally:
+
+- `getMany(ids)` delegates to the non-existent `get(id)`, so it is also broken.
+- `getAll()` is wired with `GetBlocksSuccessResponseSchema`, but the underlying `BlockDataSchema` has only 6 fields — it is missing all nested entity fields (`grower`, `vineyard`, `region`, `subRegion`, `variety`, `intendedUse`, `grading`, `fruitPlacement`) that the API actually returns.
+- `post()` returns `unknown` — no response schema validation.
+
+Consumers cannot safely access block data without type errors or runtime surprises.
+
+## Solution
+
+Remove the broken `get()` and `getMany()` methods. Expand `BlockDataSchema` to match the full OpenAPI `BlockData` component including all nested typed sub-schemas. Create a full `BlockSchema` for the `post()` response and wire it with a `BlockResponse` envelope. Add a typed `BlocksListParams` interface for `getAll()`.
+
+## User Stories
+
+1. As an SDK consumer, I want `BlocksClient.get()` removed so that I don't accidentally call a non-existent endpoint.
+2. As an SDK consumer, I want `BlocksClient.getMany()` removed so that I use `getAll()` with `VintraceEntityIds` instead.
+3. As an SDK consumer, I want `BlockData` to include all fields the API returns (`grower`, `vineyard`, `region`, `subRegion`, `variety`, `intendedUse`, `grading`, `fruitPlacement`, `description`, `rowNumbers`, `estate`) so that I can safely access them with autocomplete.
+4. As an SDK consumer, I want nested entities (`grower`, `vineyard`, `region`, `subRegion`, `variety`, `intendedUse`) to have typed `id` and `name` fields so that I don't need to cast them.
+5. As an SDK consumer, I want `fruitPlacement` to be typed with its `vintage` and `bulkStocks` array so that I can iterate over bulk stock allocations without `unknown` casts.
+6. As an SDK consumer, I want `grading` to be typed with `id`, `value`, `scaleName`, and `scaleId` so that I can read grading information safely.
+7. As an SDK consumer, I want `getAll()` to accept typed parameters (`include`, `vintage`, `VintraceEntityIds`) instead of `Record<string, unknown>` so that I get autocomplete and validation.
+8. As an SDK consumer, I want `post()` to return a properly typed `Block` response so that I can access the created block's fields without casting.
+9. As a developer, I want unit tests covering `getAll()` schema validation and `post()` response validation so that regressions are caught.
+10. As a developer, I want an integration test for `getAll()` with `include=fruitPlacements&vintage=2026` to verify real API compatibility.
+
+## Implementation Decisions
+
+1. **Remove `get(id)` and `getMany(ids)`** — The endpoint `GET /v7/harvest/blocks/{id}` does not exist. Callers needing a single block should use `getAll({ VintraceEntityIds: id, limit: 1 })`.
+2. **Expand `BlockDataSchema` to match OpenAPI `BlockData` component** — Includes `code`, `description`, `grower` (ExtIdentifiableEntity), `vineyard` (VineyardIdentifiableEntity), `region` (IdentifiableEntity), `subRegion` (IdentifiableEntity), `variety` (IdentifiableEntity), `rowNumbers`, `estate`, `intendedUse` (IdentifiableEntity), `grading` (Grading), `inactive`, `fruitPlacement` (FruitPlacement).
+3. **Reuse existing common schemas** — `ExtIdentifiableEntitySchema` already exists in the codebase. Create new sub-schemas for `VineyardIdentifiableEntity` (has nested grower), `IdentifiableEntity` (id + name), `Grading`, `FruitPlacement` (vintage + bulkStocks[]), `BulkStock`, and `Volume` (value + unit).
+4. **Create full `BlockSchema`** — 38 fields from the OpenAPI `Block` component for the `post()` `BlockResponse.data` envelope. Fields not commonly returned will be `.optional()`.
+5. **`BlockResponseSchema`** — `z.object({ data: BlockSchema })` envelope pattern consistent with `PurchaseOrderResponseSchema`.
+6. **`BlocksListParams` interface** — Typed params with `include` (string), `vintage` (string), `VintraceEntityIds` (string — CSV), `limit` (number), `offset` (number), plus standard pagination params from the spec.
+7. **`post()` return type** — `Promise<VintraceResult<Block>>` with `BlockResponseSchema` validation, unwrapping `response.data`.
+8. **No schema changes to `createAssessment()`** — That method already works and returns a separate assessment schema. Not in scope.
+9. **Schema definitions go in `src/validation/schemas.ts`** — Following the existing convention.
+10. **New types exported from `src/index.ts`** — `Block`, `BlockData`, `BlocksListParams` for external consumers.
+11. **Follow `PurchaseOrdersClient` patterns** — The most recently completed schema wiring serves as the prior art for method structure, schema wrapping, and `data` unwrapping.
+12. **`getAll()` response schema stays as `GetBlocksSuccessResponseSchema(BlockDataSchema)`** — The paginated list wrapper remains unchanged; only the inner `BlockDataSchema` expands.
+
+## Testing Decisions
+
+1. **What makes a good test**: Test external behavior only — verify the correct URL is called, validate that a valid response parses correctly and unwraps `data` where applicable, verify error handling (404, empty body, validation failure). Do not test internal implementation details.
+2. **Modules tested**: All remaining methods on `BlocksClient` — `getAll()` (with typed params, pagination logic), `post()` (response unwrapping), `createAssessment()` (existing, verify unchanged behavior).
+3. **Prior art**: `tests/unit/v7-purchase-orders.test.ts` — mock `fetch` via `vi.stubGlobal`, test happy path, 404, and empty body.
+4. **Integration test**: `tests/integration/real.integration.test.ts` — add a test for `client.v7.blocks.getAll({ include: 'fruitPlacements', vintage: '2026' })` that calls the real API and validates the response contains typed fields like `fruitPlacement.bulkStocks`.
+5. **Integration test is read-only** — GET only, following the existing read-only integration test convention.
+
+## Out of Scope
+
+- Creating a single-block `get(id)` endpoint wrapper — the endpoint simply does not exist in v7.
+- Wiring `createAssessment()` response — that method already returns a typed schema (`BlockAssessmentResponse`).
+- Any v6 blocks endpoints — this is v7 only.
+- Expanding any other client's schemas — this issue is scoped to `BlocksClient` only.
+
+## Further Notes
+
+- The `BlockData` component in the OpenAPI spec has `required: [id, name, grower, vineyard, region, variety]`. The remaining fields should be `.optional()`.
+- The `FruitPlacement` schema varies with the `include` query param — when `include=fruitPlacements` is passed, `bulkStocks` can be an array. Without it, `fruitPlacement` may be absent or empty.
+- `Grading` is `null` in many blocks — this is intentional; the schema should mark it as `.nullable()`.

--- a/src/client/VintraceClient.ts
+++ b/src/client/VintraceClient.ts
@@ -51,6 +51,8 @@ import type {
   TirageSuccessResponse,
   BarrelsMovement,
   BlockData,
+  Block,
+  BlockResponse,
   TransactionDetails,
   PurchaseOrder,
   PurchaseOrderResponse,
@@ -99,6 +101,7 @@ import {
   CreateBarrelsMovementRequestSchema,
   FruitIntakeRequestSchema,
   PurchaseOrderResponseSchema,
+  BlockResponseSchema,
 } from '../validation/schemas';
 
 export interface WorkOrderListParams {
@@ -180,6 +183,14 @@ export interface VesselDetailsReportParams {
   wineryId?: number;
   wineryName?: string;
   vesselType?: 'TANK' | 'BIN' | 'BARREL' | 'BARREL_GROUP' | 'BIN_GROUP' | 'PRESS' | 'TANKER';
+}
+
+export interface BlocksListParams {
+  include?: string;
+  vintage?: string;
+  VintraceEntityIds?: string;
+  limit?: number;
+  offset?: number;
 }
 
 export class VintraceClient {
@@ -1100,13 +1111,19 @@ class BlocksClient {
    *
    * API consumer can use the include and vintage query params to request including more information in the response.
    */
-  async getAll(params?: Record<string, unknown>): Promise<VintraceResult<BlockData[]>> {
-    const limit = params?.limit ? parseInt(String(params.limit), 10) : 100;
+  async getAll(params?: BlocksListParams): Promise<VintraceResult<BlockData[]>> {
+    const limit = params?.limit ?? 100;
+    const queryParams: Record<string, string> = { limit: String(limit), offset: '0' };
+    if (params?.include) queryParams.include = params.include;
+    if (params?.vintage) queryParams.vintage = params.vintage;
+    if (params?.VintraceEntityIds) queryParams.VintraceEntityIds = params.VintraceEntityIds;
+    if (params?.offset) queryParams.offset = String(params.offset);
+
     const firstResponse = await this.client.request<GetBlocksSuccessResponse>(
       'v7/harvest/blocks',
       'GET',
       { responseSchema: GetBlocksSuccessResponseSchema },
-      { ...params, limit: String(limit), offset: '0' }
+      queryParams
     );
 
     if (firstResponse[1]) {
@@ -1133,13 +1150,14 @@ class BlocksClient {
       const batchPromises: Promise<VintraceResult<GetBlocksSuccessResponse>>[] = [];
 
       for (let j = 0; j < batchSize; j++) {
-        const offset = (i + j) * limit;
+        const pageOffset = (i + j) * limit;
+        const pageParams: Record<string, string> = { ...queryParams, offset: String(pageOffset) };
         batchPromises.push(
           this.client.request<GetBlocksSuccessResponse>(
             'v7/harvest/blocks',
             'GET',
             { responseSchema: GetBlocksSuccessResponseSchema },
-            { ...params, limit: String(limit), offset: String(offset) }
+            pageParams
           )
         );
       }
@@ -1158,34 +1176,22 @@ class BlocksClient {
     return [allResults, null];
   }
 
-  get(id: string) {
-    /**
-     * Get a single block by id.
-     *
-     * Retrieve a single block by its id. The API supports fetching a subset of
-     * fields by using query params such as `include` and `vintage` (see server docs).
-     * Path parameter `id` is the numeric/internal identifier for the block.
-     */
-    return this.client.request<unknown>(`v7/harvest/blocks/${id}`, 'GET');
-  }
-
-  getMany(ids: string[]): Promise<VintraceResult<unknown[]>> {
-    /**
-     * Get multiple blocks by ids.
-     *
-     * Batch fetch multiple blocks by their IDs. Returns VintraceAggregateError if any request fails.
-     */
-    return batchFetch(ids, (id) => this.get(id));
-  }
-
-  post(data: unknown) {
-    /**
-     * Upsert block data into system.
-     *
-     * Create or update block data in the system. Provide a Block object in `data`.
-     * Example fields: `extId`, `name`, `estate`, `vineyard`, `variety`, `area`.
-     */
-    return this.client.request<unknown>('v7/harvest/blocks', 'POST', {}, data);
+  /**
+   * Upsert block data into system.
+   *
+   * Create or update block data in the system. Provide a Block object in `data`.
+   * Example fields: `extId`, `name`, `estate`, `vineyard`, `variety`, `area`.
+   */
+  async post(data: unknown): Promise<VintraceResult<Block>> {
+    const [response, error] = await this.client.request<BlockResponse>(
+      'v7/harvest/blocks',
+      'POST',
+      { responseSchema: BlockResponseSchema },
+      data
+    );
+    if (error) return [null, error];
+    if (!response?.data) return [null, null];
+    return [response.data, null];
   }
 
   patch(id: string, data: unknown) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export type {
   StockLookupParams,
   WineBatchesListParams,
   StockDispatchesListParams,
+  BlocksListParams,
 } from './client/VintraceClient';
 export type {
   TransactionSearchParams,
@@ -47,4 +48,6 @@ export type {
   CompositionComponent,
   PurchaseOrder,
   PurchaseOrderLine,
+  BlockData,
+  Block,
 } from './validation/schemas';

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -3,10 +3,12 @@ import { z } from 'zod';
 export const ExtIdentifiableEntitySchema = z.object({
   id: z.number().optional(),
   extId: z.string().optional(),
+  name: z.string().optional(),
 });
 
 export const IdentifiableEntitySchema = z.object({
   id: z.number().optional(),
+  name: z.string().optional(),
 });
 
 export const CodedIdentifiableEntitySchema = z.object({
@@ -643,16 +645,95 @@ export const PaginatedResponseSchema = <T extends z.ZodType>(itemSchema: T) =>
     results: z.array(itemSchema).optional(),
   });
 
+export const VineyardIdentifiableEntitySchema = z.object({
+  id: z.number().optional(),
+  name: z.string().optional(),
+  grower: ExtIdentifiableEntitySchema.optional(),
+});
+
+export const GradingSchema = z.object({
+  id: z.number().optional(),
+  value: z.string().optional(),
+  scaleName: z.string().optional(),
+  scaleId: z.number().optional(),
+});
+
+export const BulkStockSchema = z.object({
+  id: z.number().optional(),
+  productId: z.number().optional(),
+  productName: z.string().optional(),
+  vintage: z.string().optional(),
+  volume: VolumeSchema.optional(),
+  percentage: z.number().optional(),
+});
+
+export const FruitPlacementSchema = z.object({
+  vintage: z.string().optional(),
+  bulkStocks: z.array(BulkStockSchema).optional(),
+});
+
 export const BlockDataSchema = z.object({
   id: z.number(),
   code: z.string().optional(),
-  name: z.string().optional(),
-  description: z.string().optional(),
+  name: z.string(),
   extId: z.string().optional(),
   inactive: z.boolean().optional(),
+  description: z.string().optional(),
+  rowNumbers: z.string().optional(),
+  estate: z.string().optional(),
+  grower: ExtIdentifiableEntitySchema.optional(),
+  vineyard: VineyardIdentifiableEntitySchema.optional(),
+  region: IdentifiableEntitySchema.optional(),
+  subRegion: IdentifiableEntitySchema.optional(),
+  variety: IdentifiableEntitySchema.optional(),
+  intendedUse: IdentifiableEntitySchema.optional(),
+  grading: GradingSchema.nullable().optional(),
+  fruitPlacement: FruitPlacementSchema.optional(),
 });
 
 export const GetBlocksSuccessResponseSchema = PaginatedResponseSchema(BlockDataSchema);
+
+export const BlockSchema = BlockDataSchema.extend({
+  area: z.number().optional(),
+  areaUnit: z.string().optional(),
+  colour: z.string().optional(),
+  source: z.string().optional(),
+  sourceId: z.string().optional(),
+  externalId: z.string().optional(),
+  blockType: z.string().optional(),
+  directionFaced: z.string().optional(),
+  aspect: z.string().optional(),
+  slope: z.string().optional(),
+  elevation: z.number().optional(),
+  soilType: z.string().optional(),
+  drainage: z.string().optional(),
+  irrigation: z.string().optional(),
+  trellisSystem: z.string().optional(),
+  rootstock: z.string().optional(),
+  clone: z.string().optional(),
+  plantingDate: z.number().optional(),
+  plantingDateAsText: z.string().optional(),
+  rowOrientation: z.string().optional(),
+  rowSpacing: z.number().optional(),
+  vineSpacing: z.number().optional(),
+  totalVines: z.number().optional(),
+  totalArea: z.number().optional(),
+  totalAreaUnit: z.string().optional(),
+  established: z.number().optional(),
+  organic: z.boolean().optional(),
+  biodynamic: z.boolean().optional(),
+  sustainable: z.boolean().optional(),
+  certified: z.boolean().optional(),
+  notes: z.string().optional(),
+  createdDate: z.number().optional(),
+  createdDateAsText: z.string().optional(),
+  modifiedDate: z.number().optional(),
+  modifiedDateAsText: z.string().optional(),
+});
+
+export const BlockResponseSchema = z.object({
+  data: BlockSchema,
+});
 
 // ---------------------------------------------------------------------------
 // v6-style paginated responses: totalResultCount + first/max params
@@ -686,6 +767,12 @@ export const SearchListResponseSchema = V6PaginatedResponseSchema;
 
 export type GetBlocksSuccessResponse = z.infer<typeof GetBlocksSuccessResponseSchema>;
 export type BlockData = z.infer<typeof BlockDataSchema>;
+export type Block = z.infer<typeof BlockSchema>;
+export type BlockResponse = z.infer<typeof BlockResponseSchema>;
+export type VineyardIdentifiableEntity = z.infer<typeof VineyardIdentifiableEntitySchema>;
+export type Grading = z.infer<typeof GradingSchema>;
+export type BulkStock = z.infer<typeof BulkStockSchema>;
+export type FruitPlacement = z.infer<typeof FruitPlacementSchema>;
 export type InventoryResponse = z.infer<typeof InventoryResponseSchema>;
 export type TransactionSearchResponse = z.infer<typeof TransactionSearchResponseSchema>;
 export type IntakeOperationSearchResponse = z.infer<typeof IntakeOperationSearchResponseSchema>;
@@ -707,7 +794,7 @@ const WinerySchema = z.object({
   businessUnit: z.string().optional(),
 });
 
-const GradingSchema = z.object({
+const VesselGradingSchema = z.object({
   scaleId: z.number().optional(),
   scaleName: z.string().optional(),
   valueId: z.number().optional(),
@@ -725,7 +812,7 @@ const WineBatchDetailsSchema = z.object({
   program: z.string().optional(),
   productCategory: CodedIdentifiableEntitySchema.optional(),
   designatedProduct: CodedIdentifiableEntitySchema.optional(),
-  grading: GradingSchema.optional(),
+  grading: VesselGradingSchema.optional(),
 });
 
 const ProductStateSchema = z.object({

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -645,10 +645,9 @@ export const PaginatedResponseSchema = <T extends z.ZodType>(itemSchema: T) =>
     results: z.array(itemSchema).optional(),
   });
 
-export const VineyardIdentifiableEntitySchema = z.object({
-  id: z.number().optional(),
-  name: z.string().optional(),
-  grower: ExtIdentifiableEntitySchema.optional(),
+export const VineyardIdentifiableEntitySchema = IdentifiableEntitySchema.extend({
+  name: z.string(),
+  grower: ExtIdentifiableEntitySchema,
 });
 
 export const GradingSchema = z.object({
@@ -659,12 +658,14 @@ export const GradingSchema = z.object({
 });
 
 export const BulkStockSchema = z.object({
-  id: z.number().optional(),
-  productId: z.number().optional(),
-  productName: z.string().optional(),
-  vintage: z.string().optional(),
-  volume: VolumeSchema.optional(),
-  percentage: z.number().optional(),
+  totalVolume: VolumeSchema.optional(),
+  equivalentVolume: VolumeSchema.optional(),
+  equivalentWeight: VolumeSchema.optional(),
+  compWeighting: z.number().optional(),
+  percentageOfFruit: z.number().optional(),
+  batchId: z.number().optional(),
+  batchName: z.string().optional(),
+  grading: GradingSchema.nullable().optional(),
 });
 
 export const FruitPlacementSchema = z.object({
@@ -680,7 +681,7 @@ export const BlockDataSchema = z.object({
   inactive: z.boolean().optional(),
   description: z.string().optional(),
   rowNumbers: z.string().optional(),
-  estate: z.string().optional(),
+  estate: z.boolean().optional(),
   grower: ExtIdentifiableEntitySchema.optional(),
   vineyard: VineyardIdentifiableEntitySchema.optional(),
   region: IdentifiableEntitySchema.optional(),
@@ -693,42 +694,47 @@ export const BlockDataSchema = z.object({
 
 export const GetBlocksSuccessResponseSchema = PaginatedResponseSchema(BlockDataSchema);
 
-export const BlockSchema = BlockDataSchema.extend({
+export const BlockSchema = ExtIdentifiableEntitySchema.extend({
+  extId: z.string(),
+  name: z.string(),
+  estate: z.boolean().optional(),
+  vineyard: VineyardIdentifiableEntitySchema,
+  variety: IdentifiableEntitySchema,
+  countyCode: z.string().optional(),
+  inactive: z.boolean().optional(),
+  noOfVines: z.number().optional(),
   area: z.number().optional(),
-  areaUnit: z.string().optional(),
-  colour: z.string().optional(),
-  source: z.string().optional(),
-  sourceId: z.string().optional(),
-  externalId: z.string().optional(),
-  blockType: z.string().optional(),
-  directionFaced: z.string().optional(),
+  rootStock: IdentifiableEntitySchema.optional(),
+  clone: IdentifiableEntitySchema.optional(),
+  vineSpacing: z.string().optional(),
+  rowSpacing: z.string().optional(),
+  soilProfile: z.string().optional(),
+  trellis: IdentifiableEntitySchema.optional(),
   aspect: z.string().optional(),
-  slope: z.string().optional(),
-  elevation: z.number().optional(),
-  soilType: z.string().optional(),
-  drainage: z.string().optional(),
-  irrigation: z.string().optional(),
-  trellisSystem: z.string().optional(),
-  rootstock: z.string().optional(),
-  clone: z.string().optional(),
-  plantingDate: z.number().optional(),
-  plantingDateAsText: z.string().optional(),
-  rowOrientation: z.string().optional(),
-  rowSpacing: z.number().optional(),
-  vineSpacing: z.number().optional(),
-  totalVines: z.number().optional(),
-  totalArea: z.number().optional(),
-  totalAreaUnit: z.string().optional(),
-  established: z.number().optional(),
+  plantedTime: z.number().optional(),
+  pruningType: z.string().optional(),
+  averageGradient: z.number().optional(),
+  irrigationType: z.string().optional(),
+  frostProtection: z.string().optional(),
   organic: z.boolean().optional(),
-  biodynamic: z.boolean().optional(),
-  sustainable: z.boolean().optional(),
-  certified: z.boolean().optional(),
-  notes: z.string().optional(),
-  createdDate: z.number().optional(),
-  createdDateAsText: z.string().optional(),
-  modifiedDate: z.number().optional(),
-  modifiedDateAsText: z.string().optional(),
+  organicCertifiedTime: z.number().optional(),
+  township: z.string().optional(),
+  range: z.string().optional(),
+  section: z.string().optional(),
+  emitterRate: z.number().optional(),
+  emitterSize: z.string().optional(),
+  siteId: z.string().optional(),
+  noOfRows: z.number().optional(),
+  districtCode: z.string().optional(),
+  regionalAdminCode: z.string().optional(),
+  comments: z.string().optional(),
+  code: z.string().optional(),
+  defaultHarvestMethod: z.string().optional(),
+  description: z.string().optional(),
+  graftedDate: z.number().optional(),
+  intendedUse: IdentifiableEntitySchema.optional(),
+  rowNumbers: z.string().optional(),
+  vineStructure: IdentifiableEntitySchema.optional(),
 });
 
 export const BlockResponseSchema = z.object({

--- a/tests/integration/real.integration.test.ts
+++ b/tests/integration/real.integration.test.ts
@@ -156,4 +156,30 @@ describe.skipIf(!hasCredentials)('real API — read-only integration', { timeout
       expect(error).not.toBeNull();
     });
   });
+
+  // ── Blocks (v7) ──────────────────────────────────────────────────────────────
+  describe('v7.blocks', () => {
+    it('getAll() with fruitPlacements and vintage returns typed data', async () => {
+      const [data, error] = await client.v7.blocks.getAll({ include: 'fruitPlacements', vintage: '2026', limit: 5 });
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+      expect(Array.isArray(data)).toBe(true);
+      if (data && data.length > 0) {
+        const block = data[0];
+        expect(typeof block.id).toBe('number');
+        expect(typeof block.name).toBe('string');
+        if (block.grower) {
+          expect(block.grower.id).toBeDefined();
+        }
+        if (block.vineyard) {
+          expect(block.vineyard.id).toBeDefined();
+          expect(block.vineyard.name).toBeDefined();
+        }
+        if (block.region) {
+          expect(block.region.id).toBeDefined();
+          expect(block.region.name).toBeDefined();
+        }
+      }
+    });
+  });
 });

--- a/tests/unit/v7-blocks.test.ts
+++ b/tests/unit/v7-blocks.test.ts
@@ -98,7 +98,16 @@ describe('v7.blocks', () => {
 
   describe('post()', () => {
     it('calls POST v7/harvest/blocks with data and unwraps response.data', async () => {
-      const mockResponse = { data: { id: 123, name: 'New Block', code: 'NB-1' } };
+      const mockResponse = {
+        data: {
+          id: 123,
+          extId: 'EXT-001',
+          name: 'New Block',
+          code: 'NB-1',
+          vineyard: { id: 1, name: 'Test Vineyard', grower: { id: 10, extId: 'G-001' } },
+          variety: { id: 5, name: 'Pinot Noir' },
+        },
+      };
       stubFetch(200, mockResponse);
       const client = makeClient();
       const payload = { name: 'New Block', extId: 'EXT-001' };

--- a/tests/unit/v7-blocks.test.ts
+++ b/tests/unit/v7-blocks.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { VintraceClient } from '../../src/client/VintraceClient';
+
+const BASE_URL = 'https://test.vintrace.net';
+const ORG = 'testorg';
+const TOKEN = 'test-token';
+
+function makeClient() {
+  return new VintraceClient({ baseUrl: BASE_URL, organization: ORG, token: TOKEN, options: { maxRetries: 0 } });
+}
+
+function stubFetch(status: number, body: unknown) {
+  const headers = new Headers({ 'content-type': 'application/json' });
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    headers,
+    json: vi.fn().mockResolvedValue(body),
+  }));
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+const mockBlockData = {
+  id: 1,
+  name: 'Block A',
+  code: 'BLK-A',
+  grower: { id: 10, extId: 'G-001', name: 'Grower 1' },
+  vineyard: { id: 20, name: 'Vineyard 1', grower: { id: 10, extId: 'G-001', name: 'Grower 1' } },
+  region: { id: 30, name: 'Region 1' },
+  variety: { id: 40, name: 'Variety 1' },
+};
+
+const mockPaginatedResponse = {
+  totalResults: 2,
+  offset: 0,
+  limit: 100,
+  results: [mockBlockData],
+};
+
+describe('v7.blocks', () => {
+  describe('getAll()', () => {
+    it('calls GET v7/harvest/blocks with default params', async () => {
+      stubFetch(200, mockPaginatedResponse);
+      const client = makeClient();
+      const [data, error] = await client.v7.blocks.getAll();
+      expect(error).toBeNull();
+      expect(data).toHaveLength(1);
+      expect(data![0].id).toBe(1);
+      expect(data![0].name).toBe('Block A');
+      const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+      expect(url).toContain('v7/harvest/blocks');
+      expect(init.method).toBe('GET');
+    });
+
+    it('passes typed query params', async () => {
+      stubFetch(200, mockPaginatedResponse);
+      const client = makeClient();
+      await client.v7.blocks.getAll({ include: 'fruitPlacements', vintage: '2026', limit: 50 });
+      const [url] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+      expect(url).toContain('include=fruitPlacements');
+      expect(url).toContain('vintage=2026');
+      expect(url).toContain('limit=50');
+      expect(url).toContain('offset=0');
+    });
+
+    it('returns error on failure', async () => {
+      stubFetch(500, {});
+      const client = makeClient();
+      const [data, error] = await client.v7.blocks.getAll();
+      expect(data).toBeNull();
+      expect(error).not.toBeNull();
+    });
+
+    it('returns empty array on empty body', async () => {
+      stubFetch(200, {});
+      const client = makeClient();
+      const [data, error] = await client.v7.blocks.getAll();
+      expect(data).toEqual([]);
+      expect(error).toBeNull();
+    });
+
+    it('paginates across multiple pages', async () => {
+      const page1 = { totalResults: 250, limit: 100, results: Array.from({ length: 100 }, (_, i) => ({ id: i, name: `Block ${i}` })) };
+      const page2 = { totalResults: 250, limit: 100, results: Array.from({ length: 100 }, (_, i) => ({ id: 100 + i, name: `Block ${100 + i}` })) };
+      const page3 = { totalResults: 250, limit: 100, results: Array.from({ length: 50 }, (_, i) => ({ id: 200 + i, name: `Block ${200 + i}` })) };
+      const mockFetch = vi.fn()
+        .mockResolvedValueOnce({ ok: true, status: 200, headers: new Headers({ 'content-type': 'application/json' }), json: vi.fn().mockResolvedValue(page1) })
+        .mockResolvedValueOnce({ ok: true, status: 200, headers: new Headers({ 'content-type': 'application/json' }), json: vi.fn().mockResolvedValue(page2) })
+        .mockResolvedValueOnce({ ok: true, status: 200, headers: new Headers({ 'content-type': 'application/json' }), json: vi.fn().mockResolvedValue(page3) });
+      vi.stubGlobal('fetch', mockFetch);
+      const client = makeClient();
+      const [data, error] = await client.v7.blocks.getAll();
+      expect(error).toBeNull();
+      expect(data).toHaveLength(250);
+    });
+  });
+
+  describe('post()', () => {
+    it('calls POST v7/harvest/blocks with data and unwraps response.data', async () => {
+      const mockResponse = { data: { id: 123, name: 'New Block', code: 'NB-1' } };
+      stubFetch(200, mockResponse);
+      const client = makeClient();
+      const payload = { name: 'New Block', extId: 'EXT-001' };
+      const [data, error] = await client.v7.blocks.post(payload);
+      expect(error).toBeNull();
+      expect(data).toEqual(mockResponse.data);
+      const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+      expect(url).toContain('v7/harvest/blocks');
+      expect(init.method).toBe('POST');
+      expect(init.body).toBe(JSON.stringify(payload));
+    });
+
+    it('returns error on failure', async () => {
+      stubFetch(500, {});
+      const client = makeClient();
+      const [data, error] = await client.v7.blocks.post({});
+      expect(data).toBeNull();
+      expect(error).not.toBeNull();
+    });
+
+    it('returns validation error when response body is empty', async () => {
+      stubFetch(200, {});
+      const client = makeClient();
+      const [data, error] = await client.v7.blocks.post({});
+      expect(data).toBeNull();
+      expect(error).not.toBeNull();
+    });
+  });
+
+  describe('createAssessment()', () => {
+    it('calls POST v7/harvest/blocks/:id/assessments with data', async () => {
+      const mockResponse = { data: { id: 1, vintage: 2021 } };
+      stubFetch(200, mockResponse);
+      const client = makeClient();
+      const payload = { vintage: 2021 };
+      const [data, error] = await client.v7.blocks.createAssessment('123', payload);
+      expect(error).toBeNull();
+      expect(data).toEqual(mockResponse);
+      const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+      expect(url).toContain('v7/harvest/blocks/123/assessments');
+      expect(init.method).toBe('POST');
+      expect(init.body).toBe(JSON.stringify(payload));
+    });
+
+    it('returns error on server failure', async () => {
+      stubFetch(500, { message: 'Server error' });
+      const client = makeClient();
+      const [data, error] = await client.v7.blocks.createAssessment('999', {});
+      expect(data).toBeNull();
+      expect(error).not.toBeNull();
+    });
+  });
+
+  describe('patch()', () => {
+    it('calls PATCH v7/harvest/blocks/:id with data', async () => {
+      stubFetch(200, { data: { id: 1 } });
+      const client = makeClient();
+      const payload = { description: 'Updated' };
+      const [data, error] = await client.v7.blocks.patch('1', payload);
+      expect(error).toBeNull();
+      const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+      expect(url).toContain('v7/harvest/blocks/1');
+      expect(init.method).toBe('PATCH');
+      expect(init.body).toBe(JSON.stringify(payload));
+    });
+  });
+});


### PR DESCRIPTION
Summary
- Rewrite BlockSchema to match the OpenAPI Block component (was incorrectly extending BlockDataSchema with made-up fields)
- Fix BulkStockSchema — all 6 fields were wrong; replaced with the 8 real fields from the API (totalVolume, equivalentVolume, equivalentWeight, compWeighting, percentageOfFruit, batchId, batchName, grading)
- Fix estate type in BlockDataSchema from string to boolean
- Fix VineyardIdentifiableEntitySchema to extend IdentifiableEntitySchema with required name and grower per spec
- Update unit test mock response to match new required fields